### PR TITLE
28_sort_by_month_and_year

### DIFF
--- a/app/src/main/java/com/egorpoprotskiy/eyeofwages/data/MonthDao.kt
+++ b/app/src/main/java/com/egorpoprotskiy/eyeofwages/data/MonthDao.kt
@@ -27,7 +27,10 @@ interface MonthDao {
     //Получает одну запись с конкретным id.
     fun getMonth(id: Int): Flow<Month?> //Flow<Month?> - можно слушать изменения в реальном времени
 
-    @Query("SELECT * FROM Month ORDER BY id ASC")
+    //сортировка по id.
+//    @Query("SELECT * FROM Month ORDER BY id ASC")
+    //сортировка по году и месяцу.
+    @Query("SELECT * FROM Month ORDER BY yearName DESC, monthName DESC")
     //Получает все записи из таблицы Month, отсортированные по id.
     fun getAllMonths(): Flow<List<Month>>
 }


### PR DESCRIPTION
Сортировка списка из БД теперь идет сначала по году и потом по месяцу(т.е. в хронологическом порядке)